### PR TITLE
Make it possible to parse JSON containing fields with explicit null values

### DIFF
--- a/octarine-core/src/main/java/com/codepoetics/octarine/records/Record.java
+++ b/octarine-core/src/main/java/com/codepoetics/octarine/records/Record.java
@@ -32,7 +32,11 @@ public interface Record {
     }
 
     public static Record of(Stream<Value> values) {
-        return new HashRecord(HashTreePMap.from(values.collect(Collectors.toMap(Value::key, Value::value))));
+        /*
+         * Collectors.toMap will call HashMap.merge() which will throw a NullPointerException if supplied with a null
+         * for the value parameter, so filter out null values first.
+         */
+        return new HashRecord(HashTreePMap.from(values.filter(v -> null != v.value()).collect(Collectors.toMap(Value::key, Value::value))));
     }
 
     <T> Optional<T> get(Key<? extends T> key);

--- a/octarine-json/src/test/java/com/codepoetics/octarine/json/DeserialisationTest.java
+++ b/octarine-json/src/test/java/com/codepoetics/octarine/json/DeserialisationTest.java
@@ -167,4 +167,13 @@ public class DeserialisationTest {
         assertThat(theNumbers, ARecord.instance()
                 .with(numbers.join(Path.toKey("home")).join(prefix), "0208"));
     }
+
+    @Test
+    public void
+    can_deserialise_a_record_containing_explicit_nulls() {
+        String json = "{\"numbers\": {\"home\": {\"prefix\": null, \"number\": \"123456\"}}}";
+        Record theNumbers = readNumbers.fromString(json);
+        assertThat(theNumbers, ARecord.instance()
+                .with(numbers.join(Path.toKey("home")).join(number), "123456"));
+    }
 }


### PR DESCRIPTION
For example the following would previously cause a NullPointerException in HashMap.merge()

```
{
  "prefix" : null,
  "number" : "123456"
}
```