### PR TITLE
Code to serialise to/from BsonDocument

### DIFF
--- a/octarine-bson/pom.xml
+++ b/octarine-bson/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>octarine</artifactId>
+        <groupId>com.codepoetics</groupId>
+        <version>0.17-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>octarine-bson</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.codepoetics</groupId>
+            <artifactId>octarine-core</artifactId>
+            <version>0.17-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongo-java-driver</artifactId>
+            <version>3.0.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.npathai</groupId>
+            <artifactId>hamcrest-optional</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/octarine-bson/src/main/java/com/codepoetics/octarine/bson/deserialisation/BsonDeserialisationException.java
+++ b/octarine-bson/src/main/java/com/codepoetics/octarine/bson/deserialisation/BsonDeserialisationException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson.deserialisation;
+
+import org.bson.BsonInvalidOperationException;
+
+public class BsonDeserialisationException extends RuntimeException {
+    public BsonDeserialisationException(BsonInvalidOperationException e) {
+        super(e);
+    }
+
+    public BsonDeserialisationException(String msg) {
+        super(msg);
+    }
+}

--- a/octarine-bson/src/main/java/com/codepoetics/octarine/bson/deserialisation/BsonDeserialiser.java
+++ b/octarine-bson/src/main/java/com/codepoetics/octarine/bson/deserialisation/BsonDeserialiser.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson.deserialisation;
+
+
+import org.bson.BsonValue;
+
+import java.util.function.Function;
+
+public interface BsonDeserialiser<R> extends Function<BsonValue, R> {
+}

--- a/octarine-bson/src/main/java/com/codepoetics/octarine/bson/deserialisation/BsonDeserialisers.java
+++ b/octarine-bson/src/main/java/com/codepoetics/octarine/bson/deserialisation/BsonDeserialisers.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson.deserialisation;
+
+
+import com.codepoetics.octarine.records.Valid;
+import com.codepoetics.octarine.records.Validation;
+import org.bson.BsonValue;
+import org.bson.types.ObjectId;
+
+import java.util.Date;
+import java.util.function.Function;
+
+public interface BsonDeserialisers {
+
+    SafeBsonDeserialiser<Boolean> ofBoolean = (v) -> v.asBoolean().getValue();
+
+    SafeBsonDeserialiser<Date> ofDate = (v) -> new Date(v.asDateTime().getValue());
+
+    SafeBsonDeserialiser<Double> ofDouble = (v) -> v.asDouble().getValue();
+
+    SafeBsonDeserialiser<Integer> ofInteger = (v) -> v.asInt32().getValue();
+
+    SafeBsonDeserialiser<Long> ofLong = (v) -> v.asInt64().getValue();
+
+    SafeBsonDeserialiser<ObjectId> ofObjectId = (v) -> v.asObjectId().getValue();
+
+    SafeBsonDeserialiser<String> ofString = (v) -> v.asString().getValue();
+
+    static <V> SafeBsonDeserialiser<Valid<V>> ofValid(Function<BsonValue, ? extends Validation<V>> deserialiser) {
+        return parser -> deserialiser.apply(parser).get();
+    }
+}

--- a/octarine-bson/src/main/java/com/codepoetics/octarine/bson/deserialisation/BsonListDeserialiser.java
+++ b/octarine-bson/src/main/java/com/codepoetics/octarine/bson/deserialisation/BsonListDeserialiser.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson.deserialisation;
+
+
+import org.bson.BsonArray;
+import org.bson.BsonInvalidOperationException;
+import org.bson.BsonValue;
+import org.pcollections.PVector;
+import org.pcollections.TreePVector;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class BsonListDeserialiser<V> implements SafeBsonDeserialiser<PVector<V>> {
+    public static <V> BsonListDeserialiser<V> readingItemsWith(BsonDeserialiser<? extends V> itemDeserialiser) {
+        return new BsonListDeserialiser<>(itemDeserialiser);
+    }
+
+    private final BsonDeserialiser<? extends V> itemDeserialiser;
+
+    private BsonListDeserialiser(BsonDeserialiser<? extends V> itemSerialiser) {
+        this.itemDeserialiser = itemSerialiser;
+    }
+
+    @Override
+    public PVector<V> applyUnsafe(BsonValue p) throws BsonInvalidOperationException {
+        BsonArray bsonArray = p.asArray();
+        List<V> values = bsonArray.getValues().stream().map(v -> itemDeserialiser.apply(v)).collect(Collectors.toList());
+        return TreePVector.from(values);
+    }
+}

--- a/octarine-bson/src/main/java/com/codepoetics/octarine/bson/deserialisation/BsonMapDeserialiser.java
+++ b/octarine-bson/src/main/java/com/codepoetics/octarine/bson/deserialisation/BsonMapDeserialiser.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson.deserialisation;
+
+
+import org.bson.BsonDocument;
+import org.bson.BsonInvalidOperationException;
+import org.bson.BsonValue;
+import org.pcollections.HashTreePMap;
+import org.pcollections.PMap;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BsonMapDeserialiser<T> implements SafeBsonDeserialiser<PMap<String, T>> {
+    public static <T> BsonMapDeserialiser<T> readingValuesWith(BsonDeserialiser<? extends T> valueDeserialiser) {
+        return new BsonMapDeserialiser<>(valueDeserialiser);
+    }
+
+    private final BsonDeserialiser<? extends T> valueDeserialiser;
+
+    private BsonMapDeserialiser(BsonDeserialiser<? extends T> valueDeserialiser) {
+        this.valueDeserialiser = valueDeserialiser;
+    }
+
+    @Override
+    public PMap<String, T> applyUnsafe(BsonValue p) throws BsonInvalidOperationException {
+        BsonDocument doc = p.asDocument();
+        Map<String, T> values = new HashMap<>();
+        for (Map.Entry<String,BsonValue> e : doc.entrySet()) {
+            values.put(e.getKey(), valueDeserialiser.apply(e.getValue()));
+        }
+
+        return HashTreePMap.from(values);
+    }
+}

--- a/octarine-bson/src/main/java/com/codepoetics/octarine/bson/deserialisation/BsonRecordDeserialiser.java
+++ b/octarine-bson/src/main/java/com/codepoetics/octarine/bson/deserialisation/BsonRecordDeserialiser.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson.deserialisation;
+
+
+import com.codepoetics.octarine.records.Key;
+import com.codepoetics.octarine.records.ListKey;
+import com.codepoetics.octarine.records.Record;
+import com.codepoetics.octarine.records.Schema;
+import com.codepoetics.octarine.records.Valid;
+import com.codepoetics.octarine.records.Validation;
+import com.codepoetics.octarine.records.Value;
+import org.bson.BsonDocument;
+import org.bson.BsonInvalidOperationException;
+import org.bson.BsonValue;
+import org.bson.types.ObjectId;
+import org.pcollections.PMap;
+
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+public class BsonRecordDeserialiser implements SafeBsonDeserialiser<Record> {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder implements Supplier<BsonRecordDeserialiser> {
+
+        private final Map<Key<?>, Function<Map<String, BsonValue>, Optional<Value>>> deserialiserMap = new LinkedHashMap<>();
+
+        public <V> Builder read(Key<? super V> key, String fieldName, Function<BsonValue, ? extends V> deserialiser) {
+            Function<Map<String, BsonValue>, Optional<Value>> keyValueReader = (m) -> {
+                BsonValue v = m.get(fieldName);
+                return (null == v) ? Optional.empty() : Optional.of(key.of(deserialiser.apply(v)));
+            };
+            deserialiserMap.put(key, keyValueReader);
+            return this;
+        }
+
+        public <V> Builder read(Key<? super V> key, Function<BsonValue, ? extends V> deserialiser) {
+            return read(key, key.name(), deserialiser);
+        }
+
+        public <V> Builder read(Key<V> key, Supplier<Function<BsonValue, V>> deserialiserSupplier) {
+            return read(key, deserialiserSupplier.get());
+        }
+
+        public <V> Builder read(Key<V> key, String fieldName, Supplier<Function<BsonValue, V>> deserialiserSupplier) {
+            return read(key, fieldName, deserialiserSupplier.get());
+        }
+
+        public Builder readBoolean(Key<Boolean> key) {
+            return read(key, BsonDeserialisers.ofBoolean);
+        }
+
+        public Builder readBoolean(Key<Boolean> key, String fieldName) {
+            return read(key, fieldName, BsonDeserialisers.ofBoolean);
+        }
+
+        public Builder readDate(Key<Date> key) {
+            return read(key, BsonDeserialisers.ofDate);
+        }
+
+        public Builder readDate(Key<Date> key, String fieldName) {
+            return read(key, fieldName, BsonDeserialisers.ofDate);
+        }
+
+        public Builder readDouble(Key<Double> key) {
+            return read(key, BsonDeserialisers.ofDouble);
+        }
+
+        public Builder readDouble(Key<Double> key, String fieldName) {
+            return read(key, fieldName, BsonDeserialisers.ofDouble);
+        }
+
+        public Builder readInteger(Key<Integer> key) {
+            return read(key, BsonDeserialisers.ofInteger);
+        }
+
+        public Builder readInteger(Key<Integer> key, String fieldName) {
+            return read(key, fieldName, BsonDeserialisers.ofInteger);
+        }
+
+        public Builder readLong(Key<Long> key) {
+            return read(key, BsonDeserialisers.ofLong);
+        }
+
+        public Builder readLong(Key<Long> key, String fieldName) {
+            return read(key, fieldName, BsonDeserialisers.ofLong);
+        }
+
+        public Builder readObjectId(Key<ObjectId> key) {
+            return read(key, BsonDeserialisers.ofObjectId);
+        }
+
+        public Builder readObjectId(Key<ObjectId> key, String fieldName) {
+            return read(key, fieldName, BsonDeserialisers.ofObjectId);
+        }
+
+        public Builder readString(Key<String> key) {
+            return read(key, BsonDeserialisers.ofString);
+        }
+
+        public Builder readString(Key<String> key, String fieldName) {
+            return read(key, fieldName, BsonDeserialisers.ofString);
+        }
+
+        public <V> Builder readList(ListKey<V> key, BsonDeserialiser<? extends V> itemDeserialiser) {
+            return read(key, BsonListDeserialiser.readingItemsWith(itemDeserialiser));
+        }
+
+        public <V> Builder readList(ListKey<V> key, String fieldName, BsonDeserialiser<? extends V> itemDeserialiser) {
+            return read(key, fieldName, BsonListDeserialiser.readingItemsWith(itemDeserialiser));
+        }
+
+        public <V> Builder readMap(Key<PMap<String, V>> key, BsonDeserialiser<? extends V> valueDeserialiser) {
+            return read(key, BsonMapDeserialiser.readingValuesWith(valueDeserialiser));
+        }
+
+        public <V> Builder readMap(Key<PMap<String, V>> key, String fieldName, BsonDeserialiser<? extends V> valueDeserialiser) {
+            return read(key, fieldName, BsonMapDeserialiser.readingValuesWith(valueDeserialiser));
+        }
+
+        public <V> Builder readValidRecord(Key<Valid<V>> key, Function<BsonValue, Validation<V>> deserialiser) {
+            return read(key, BsonDeserialisers.ofValid(deserialiser));
+        }
+
+        @Override
+        public BsonRecordDeserialiser get() {
+            return new BsonRecordDeserialiser(deserialiserMap);
+        }
+    }
+
+    private final Map<Key<?>, Function<Map<String, BsonValue>, Optional<Value>>> deserialiserMap;
+
+    public BsonRecordDeserialiser(Map<Key<?>, Function<Map<String, BsonValue>, Optional<Value>>> deserialiserMap) {
+        this.deserialiserMap = deserialiserMap;
+    }
+
+    @Override
+    public Record applyUnsafe(BsonValue bsonValue) throws BsonInvalidOperationException {
+        return Record.of(valuesFrom(bsonValue));
+    }
+
+    Stream<Value> valuesFrom(BsonValue bsonValue) throws BsonInvalidOperationException {
+        BsonDocument doc = bsonValue.asDocument();
+        return deserialiserMap.values().stream()
+                .map(d -> d.apply(doc))
+                .filter(Optional::isPresent)
+                .map(Optional::get);
+    }
+
+    public <S> BsonDeserialiser<Validation<S>> validAgainst(Schema<S> schema) {
+        return new BsonValidRecordDeserialiser<>(schema, this);
+    }
+}

--- a/octarine-bson/src/main/java/com/codepoetics/octarine/bson/deserialisation/BsonValidRecordDeserialiser.java
+++ b/octarine-bson/src/main/java/com/codepoetics/octarine/bson/deserialisation/BsonValidRecordDeserialiser.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson.deserialisation;
+
+import com.codepoetics.octarine.records.Record;
+import com.codepoetics.octarine.records.RecordValidationException;
+import com.codepoetics.octarine.records.Schema;
+import com.codepoetics.octarine.records.Validation;
+import org.bson.BsonInvalidOperationException;
+import org.bson.BsonValue;
+
+
+public class BsonValidRecordDeserialiser<T> implements SafeBsonDeserialiser<Validation<T>> {
+
+    private final Schema<T> schema;
+
+    private final BsonRecordDeserialiser reader;
+
+    public BsonValidRecordDeserialiser(Schema<T> schema, BsonRecordDeserialiser reader) {
+        this.schema = schema;
+        this.reader = reader;
+    }
+
+    @Override
+    public Validation<T> applyUnsafe(BsonValue p) throws BsonInvalidOperationException {
+        try {
+            return validated(reader.apply(p));
+        } catch (RecordValidationException e) {
+            return e.toValidation();
+        }
+    }
+
+    private Validation<T> validated(Record record) {
+        return schema.validate(record);
+    }
+}

--- a/octarine-bson/src/main/java/com/codepoetics/octarine/bson/deserialisation/SafeBsonDeserialiser.java
+++ b/octarine-bson/src/main/java/com/codepoetics/octarine/bson/deserialisation/SafeBsonDeserialiser.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson.deserialisation;
+
+import org.bson.BsonInvalidOperationException;
+import org.bson.BsonValue;
+
+public interface SafeBsonDeserialiser<S> extends BsonDeserialiser<S> {
+    default S apply(BsonValue p) {
+        try {
+            return applyUnsafe(p);
+        } catch (BsonInvalidOperationException e) {
+            throw new BsonDeserialisationException(e);
+        }
+    }
+
+    S applyUnsafe(BsonValue p) throws BsonInvalidOperationException;
+}

--- a/octarine-bson/src/main/java/com/codepoetics/octarine/bson/serialisation/BsonListSerialiser.java
+++ b/octarine-bson/src/main/java/com/codepoetics/octarine/bson/serialisation/BsonListSerialiser.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson.serialisation;
+
+
+import org.bson.BsonArray;
+import org.bson.BsonValue;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class BsonListSerialiser<T> implements SafeBsonSerialiser<Collection<? extends T>> {
+    public static <T> BsonListSerialiser<T> writingItemsWith(BsonSerialiser<? super T> itemSerialiser) {
+        return new BsonListSerialiser<>(itemSerialiser);
+    }
+
+    private final BsonSerialiser<? super T> itemSerialiser;
+
+    private BsonListSerialiser(BsonSerialiser<? super T> itemSerialiser) {
+        this.itemSerialiser = itemSerialiser;
+    }
+
+    @Override
+    public BsonValue applyUnsafe(Collection<? extends T> values) throws IOException {
+        List<BsonValue> bvalues = values.stream().map(v -> itemSerialiser.apply(v)).collect(Collectors.toList());
+        return new BsonArray(bvalues);
+    }
+}

--- a/octarine-bson/src/main/java/com/codepoetics/octarine/bson/serialisation/BsonMapSerialiser.java
+++ b/octarine-bson/src/main/java/com/codepoetics/octarine/bson/serialisation/BsonMapSerialiser.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson.serialisation;
+
+
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class BsonMapSerialiser<T> implements SafeBsonSerialiser<Map<String, ? extends T>> {
+    public static <T> BsonMapSerialiser<T> writingValuesWith(BsonSerialiser<? super T> valueSerialiser) {
+        return new BsonMapSerialiser<>(valueSerialiser);
+    }
+
+    private final BsonSerialiser<? super T> valueSerialiser;
+
+    private BsonMapSerialiser(BsonSerialiser<? super T> valueSerialiser) {
+        this.valueSerialiser = valueSerialiser;
+    }
+
+    @Override
+    public BsonValue applyUnsafe(Map<String, ? extends T> values) throws IOException {
+        final BsonDocument doc = new BsonDocument();
+        for (Map.Entry<String, ? extends T> e : values.entrySet()) {
+            doc.put(e.getKey(), valueSerialiser.apply(e.getValue()));
+        }
+        return doc;
+    }
+}

--- a/octarine-bson/src/main/java/com/codepoetics/octarine/bson/serialisation/BsonRecordSerialiser.java
+++ b/octarine-bson/src/main/java/com/codepoetics/octarine/bson/serialisation/BsonRecordSerialiser.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson.serialisation;
+
+
+import com.codepoetics.octarine.records.Key;
+import com.codepoetics.octarine.records.Record;
+import org.bson.BsonDocument;
+import org.bson.BsonElement;
+import org.bson.BsonValue;
+import org.bson.types.ObjectId;
+import org.pcollections.PVector;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+
+public class BsonRecordSerialiser implements SafeBsonSerialiser<Record> {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder implements Supplier<BsonRecordSerialiser> {
+        private final Map<Key<?>, Function<?, BsonElement>> serialiserMap = new LinkedHashMap<>();
+
+        public <V> Builder write(Key<? extends V> key, String fieldName, Function<? super V, BsonValue> serialiser) {
+            Function<? extends V, BsonElement> keyValueWriter = (V value) ->
+                    new BsonElement(fieldName, serialiser.apply(value));
+            serialiserMap.put(key, keyValueWriter);
+            return this;
+        }
+
+        public <V> Builder write(Key<? extends V> key, Function<? super V, BsonValue> serialiser) {
+            return write(key, key.name(), serialiser);
+        }
+
+        public <V> Builder write(Key<? extends V> key, Supplier<Function<? super V, BsonValue>> serialiserSupplier) {
+            return write(key, serialiserSupplier.get());
+        }
+
+        public <V> Builder write(Key<? extends V> key, String fieldName, Supplier<Function<? super V, BsonValue>> serialiserSupplier) {
+            return write(key, fieldName, serialiserSupplier.get());
+        }
+
+        public Builder writeBoolean(Key<Boolean> key) {
+            return write(key, BsonSerialisers.toBoolean);
+        }
+
+        public Builder writeBoolean(Key<Boolean> key, String fieldName) {
+            return write(key, fieldName, BsonSerialisers.toBoolean);
+        }
+
+        public Builder writeDate(Key<Date> key) {
+            return write(key, BsonSerialisers.toDate);
+        }
+
+        public Builder writeDate(Key<Date> key, String fieldName) {
+            return write(key, fieldName, BsonSerialisers.toDate);
+        }
+
+        public Builder writeDouble(Key<Double> key) {
+            return write(key, BsonSerialisers.toDouble);
+        }
+
+        public Builder writeDouble(Key<Double> key, String fieldName) {
+            return write(key, fieldName, BsonSerialisers.toDouble);
+        }
+
+        public Builder writeInteger(Key<Integer> key) {
+            return write(key, BsonSerialisers.toInteger);
+        }
+
+        public Builder writeInteger(Key<Integer> key, String fieldName) {
+            return write(key, fieldName, BsonSerialisers.toInteger);
+        }
+
+        public Builder writeLong(Key<Long> key) {
+            return write(key, BsonSerialisers.toLong);
+        }
+
+        public Builder writeLong(Key<Long> key, String fieldName) {
+            return write(key, fieldName, BsonSerialisers.toLong);
+        }
+
+        public Builder writeObjectId(Key<ObjectId> key) {
+            return write(key, BsonSerialisers.toObjectId);
+        }
+
+        public Builder writeObjectId(Key<ObjectId> key, String fieldName) {
+            return write(key, fieldName, BsonSerialisers.toObjectId);
+        }
+
+        public Builder writeString(Key<String> key) {
+            return write(key, BsonSerialisers.toString);
+        }
+
+        public Builder writeString(Key<String> key, String fieldName) {
+            return write(key, fieldName, BsonSerialisers.toString);
+        }
+
+        public <T> Builder writeList(Key<PVector<T>> key, BsonSerialiser<? super T> itemSerialiser) {
+            return write(key, BsonListSerialiser.writingItemsWith(itemSerialiser));
+        }
+
+        public <T> Builder writeList(Key<PVector<T>> key, String fieldName, BsonSerialiser<? super T> itemSerialiser) {
+            return write(key, fieldName, BsonListSerialiser.writingItemsWith(itemSerialiser));
+        }
+
+        public <V> Builder writeMap(Key<Map<String, V>> key, BsonSerialiser<V> valueSerialiser) {
+            return write(key, BsonMapSerialiser.writingValuesWith(valueSerialiser));
+        }
+
+        public <V> Builder writeMap(Key<Map<String, V>> key, String fieldName, BsonSerialiser<V> valueSerialiser) {
+            return write(key, fieldName, BsonMapSerialiser.writingValuesWith(valueSerialiser));
+        }
+
+        @Override
+        public BsonRecordSerialiser get() {
+            return new BsonRecordSerialiser(serialiserMap);
+        }
+    }
+
+    private final Map<Key<?>, Function<?, BsonElement>> serialiserMap;
+
+    public BsonRecordSerialiser(Map<Key<?>, Function<?, BsonElement>> serialiserMap) {
+        this.serialiserMap = serialiserMap;
+    }
+
+    @Override
+    public BsonDocument applyUnsafe(Record record) throws IOException {
+        List<BsonElement> elems = serialiserMap.entrySet().stream()
+                .filter(e -> e.getKey().get(record).isPresent())
+                .map(e -> ((Function<Object, BsonElement>) serialiserMap.get(e.getKey())).apply(e.getKey().get(record).get()))
+                .collect(Collectors.toList());
+        return new BsonDocument(elems);
+    }
+}

--- a/octarine-bson/src/main/java/com/codepoetics/octarine/bson/serialisation/BsonSerialisationException.java
+++ b/octarine-bson/src/main/java/com/codepoetics/octarine/bson/serialisation/BsonSerialisationException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson.serialisation;
+
+
+import java.io.IOException;
+
+public class BsonSerialisationException extends RuntimeException {
+
+    public BsonSerialisationException(IOException cause) {
+        super(cause);
+    }
+
+    public IOException getIOExceptionCause() {
+        return (IOException) getCause();
+    }
+}

--- a/octarine-bson/src/main/java/com/codepoetics/octarine/bson/serialisation/BsonSerialiser.java
+++ b/octarine-bson/src/main/java/com/codepoetics/octarine/bson/serialisation/BsonSerialiser.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson.serialisation;
+
+
+import org.bson.BsonValue;
+
+import java.util.function.Function;
+
+public interface BsonSerialiser<R> extends Function<R, BsonValue> {
+}

--- a/octarine-bson/src/main/java/com/codepoetics/octarine/bson/serialisation/BsonSerialisers.java
+++ b/octarine-bson/src/main/java/com/codepoetics/octarine/bson/serialisation/BsonSerialisers.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson.serialisation;
+
+
+import org.bson.BsonBoolean;
+import org.bson.BsonDateTime;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonObjectId;
+import org.bson.BsonString;
+import org.bson.types.ObjectId;
+
+import java.util.Date;
+
+public interface BsonSerialisers {
+
+    BsonSerialiser<Boolean> toBoolean = (v) -> new BsonBoolean(v);
+
+    BsonSerialiser<Date> toDate = (v) -> new BsonDateTime(v.getTime());
+
+    BsonSerialiser<Double> toDouble = (v) -> new BsonDouble(v);
+
+    BsonSerialiser<Integer> toInteger = (v) -> new BsonInt32(v);
+
+    BsonSerialiser<Long> toLong = (v) -> new BsonInt64(v);
+
+    BsonSerialiser<ObjectId> toObjectId = (v) -> new BsonObjectId(v);
+
+    BsonSerialiser<String> toString = (v) -> new BsonString(v);
+}

--- a/octarine-bson/src/main/java/com/codepoetics/octarine/bson/serialisation/SafeBsonSerialiser.java
+++ b/octarine-bson/src/main/java/com/codepoetics/octarine/bson/serialisation/SafeBsonSerialiser.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson.serialisation;
+
+import org.bson.BsonValue;
+
+import java.io.IOException;
+
+public interface SafeBsonSerialiser<T> extends BsonSerialiser<T> {
+    default BsonValue apply(T value) {
+        try {
+            return applyUnsafe(value);
+        } catch (IOException e) {
+            throw new BsonSerialisationException(e);
+        }
+    }
+
+    BsonValue applyUnsafe(T value) throws IOException;
+}

--- a/octarine-bson/src/test/java/com/codepoetics/octarine/bson/BsonToRecord.java
+++ b/octarine-bson/src/test/java/com/codepoetics/octarine/bson/BsonToRecord.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson;
+
+
+import com.codepoetics.octarine.bson.data.Address;
+import com.codepoetics.octarine.bson.data.Person;
+import com.codepoetics.octarine.bson.deserialisation.BsonDeserialisers;
+import com.codepoetics.octarine.bson.deserialisation.BsonRecordDeserialiser;
+import com.codepoetics.octarine.records.Record;
+import com.codepoetics.octarine.records.Valid;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.junit.Test;
+import org.pcollections.PVector;
+
+import java.awt.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BsonToRecord {
+
+    public static final List<String> ADDRESS_LINES = Arrays.asList("13 Rue Morgue", "PO3 1TP");
+
+    @Test public void
+    convert_bson_to_record() {
+        BsonDocument doc = new BsonDocument();
+        doc.put("name", new BsonString("Dominic"));
+        doc.put("age", new BsonInt32(39));
+
+        BsonRecordDeserialiser deserialiser = BsonRecordDeserialiser.builder()
+                .readString(Person.name)
+                .readInteger(Person.age)
+                .get();
+
+        Record result = deserialiser.apply(doc);
+        assertTrue("name not set", Person.name.get(result).isPresent());
+        assertEquals("incorrect name", "Dominic", Person.name.get(result).get());
+        assertTrue("age not set", Person.age.get(result).isPresent());
+        assertEquals("incorrect age", 39, (int) Person.age.get(result).get());
+    }
+
+    @Test public void
+    convert_bson_to_record_when_field_names_do_not_match_key_names() {
+        BsonDocument doc = new BsonDocument();
+        doc.put("foo", new BsonString("Dominic"));
+        doc.put("bar", new BsonInt32(39));
+
+        BsonRecordDeserialiser deserialiser = BsonRecordDeserialiser.builder()
+                .readString(Person.name, "foo")
+                .readInteger(Person.age, "bar")
+                .get();
+
+        Record result = deserialiser.apply(doc);
+        assertTrue("name not set", Person.name.get(result).isPresent());
+        assertEquals("incorrect name", "Dominic", Person.name.get(result).get());
+        assertTrue("age not set", Person.age.get(result).isPresent());
+        assertEquals("incorrect age", 39, (int) Person.age.get(result).get());
+    }
+
+    @Test public void
+    convert_nested_bson_to_record() {
+        BsonDocument doc = new BsonDocument();
+        doc.put("name", new BsonString("Dominic"));
+        doc.put("age", new BsonInt32(39));
+        BsonDocument address = new BsonDocument();
+        BsonArray addressLines = new BsonArray(ADDRESS_LINES.stream()
+                .map(s -> new BsonString(s))
+                .collect(Collectors.toList()));
+        address.put("addressLines", addressLines);
+        doc.put("address", address);
+
+        BsonRecordDeserialiser addressDeserialiser = BsonRecordDeserialiser.builder()
+                .readList(Address.addressLines, BsonDeserialisers.ofString)
+                .get();
+
+        BsonRecordDeserialiser deserialiser = BsonRecordDeserialiser.builder()
+                .readString(Person.name)
+                .readInteger(Person.age)
+                .readValidRecord(Person.address, addressDeserialiser.validAgainst(Address.schema))
+                .get();
+
+        Record result = deserialiser.apply(doc);
+        assertTrue("name not set", Person.name.get(result).isPresent());
+        assertEquals("incorrect name", "Dominic", Person.name.get(result).get());
+        assertTrue("age not set", Person.age.get(result).isPresent());
+        assertEquals("incorrect age", 39, (int) Person.age.get(result).get());
+        Optional<Valid<Address>> maybeAddress = Person.address.get(result);
+        assertTrue("Address not present", maybeAddress.isPresent());
+        Optional<PVector<String>> maybeLines = Address.addressLines.get(maybeAddress.get());
+        assertThat(maybeLines, not(isEmpty()));
+        assertEquals("Address lines don't match", ADDRESS_LINES, maybeLines.get());
+    }
+
+    @Test public void
+    convert_bson_to_record_with_custom_type() {
+        BsonDocument doc = new BsonDocument();
+        doc.put("foo", new BsonString("Dominic"));
+        doc.put("bar", new BsonInt32(39));
+        doc.put("favouriteColour", new BsonString("0xFF0000"));
+
+        BsonRecordDeserialiser deserialiser = BsonRecordDeserialiser.builder()
+                .readString(Person.name)
+                .readInteger(Person.age)
+                .read(Person.favouriteColour, Person.colourFromBson)
+                .get();
+
+        Record result = deserialiser.apply(doc);
+        assertThat(Person.favouriteColour.get(result), not(isEmpty()));
+        assertEquals("mismatched colour", Color.RED, Person.favouriteColour.get(result).get());
+    }
+}

--- a/octarine-bson/src/test/java/com/codepoetics/octarine/bson/DeserialisationTest.java
+++ b/octarine-bson/src/test/java/com/codepoetics/octarine/bson/DeserialisationTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson;
+
+
+import com.codepoetics.octarine.bson.deserialisation.BsonDeserialisers;
+import com.codepoetics.octarine.bson.deserialisation.BsonMapDeserialiser;
+import com.codepoetics.octarine.bson.deserialisation.BsonRecordDeserialiser;
+import com.codepoetics.octarine.records.Key;
+import com.codepoetics.octarine.records.Record;
+import org.bson.BsonBoolean;
+import org.bson.BsonDateTime;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonObjectId;
+import org.bson.BsonString;
+import org.bson.types.ObjectId;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DeserialisationTest {
+    Random random = new Random();
+
+    @Test public void
+    read_map_from_bson() {
+        BsonDocument doc = new BsonDocument();
+        doc.put("foo", new BsonInt32(42));
+        doc.put("bar", new BsonInt32(666));
+
+        Map<String, Integer> deserialised = BsonMapDeserialiser
+                .readingValuesWith(BsonDeserialisers.ofInteger)
+                .apply(doc);
+
+        // need the cast to long to enable javac to disambiguate between varians of assertEquals
+        assertEquals("invalid foo", 42, (int) deserialised.get("foo"));
+        assertEquals("invalid bar", 666, (int) deserialised.get("bar"));
+    }
+
+    @Test public void
+    deserialise_boolean() {
+        Key<Boolean> booleanKey = Key.named("my-value");
+
+        BsonRecordDeserialiser deserialiser = BsonRecordDeserialiser.builder()
+                .readBoolean(booleanKey)
+                .get();
+
+        BsonDocument trueDoc = new BsonDocument();
+        trueDoc.put("my-value", new BsonBoolean(true));
+        Record trueRecord = deserialiser.apply(trueDoc);
+        assertTrue("wasn't true", booleanKey.get(trueRecord).get());
+
+        BsonDocument falseDoc = new BsonDocument();
+        falseDoc.put("my-value", new BsonBoolean(false));
+        Record falseRecord = Record.of(booleanKey.of(false));
+        assertFalse("wasn't false", booleanKey.get(falseRecord).get());
+    }
+
+    @Test public void
+    deserialise_date() {
+        Date value = new Date();
+        Key<Date> dateKey = Key.named("my-value");
+        BsonDocument doc = new BsonDocument();
+        doc.put("my-value", new BsonDateTime(value.getTime()));
+
+        Record record = BsonRecordDeserialiser.builder()
+                .readDate(dateKey)
+                .get()
+                .apply(doc);
+        assertEquals("wrong date value", value, dateKey.get(record).get());
+    }
+
+    @Test public void
+    deserialise_double() {
+        double value = random.nextDouble();
+        BsonDocument doc = new BsonDocument();
+        doc.put("my-value", new BsonDouble(value));
+
+        Key<Double> doubleKey = Key.named("my-value");
+        Record record = BsonRecordDeserialiser.builder()
+                .readDouble(doubleKey)
+                .get()
+                .apply(doc);
+        assertEquals("wrong double value", value, doubleKey.get(record).get(), 0.0001);
+    }
+
+    @Test public void
+    deserialise_integer() {
+        int value = random.nextInt();
+        BsonDocument doc = new BsonDocument();
+        doc.put("my-value", new BsonInt32(value));
+        Key<Integer> integerKey = Key.named("my-value");
+
+        Record record = BsonRecordDeserialiser.builder()
+                .readInteger(integerKey)
+                .get()
+                .apply(doc);
+        assertEquals("wrong int value", value, (int) integerKey.get(record).get());
+    }
+
+    @Test public void
+    deserialise_long() {
+        long value = random.nextLong();
+        BsonDocument doc = new BsonDocument();
+        doc.put("my-value", new BsonInt64(value));
+        Key<Long> longKey = Key.named("my-value");
+
+        Record record = BsonRecordDeserialiser.builder()
+                .readLong(longKey)
+                .get()
+                .apply(doc);
+        assertEquals("wrong long value", value, (long) longKey.get(record).get());
+    }
+
+    @Test public void
+    deserialise_object_id() {
+        ObjectId value = new ObjectId(new Date(), random.nextInt(0xffffff));
+        BsonDocument doc = new BsonDocument();
+        doc.put("my-value", new BsonObjectId(value));
+        Key<ObjectId> idKey = Key.named("my-value");
+
+        Record record = BsonRecordDeserialiser.builder()
+                .readObjectId(idKey)
+                .get()
+                .apply(doc);
+        assertEquals("wrong ObjectId value", value, idKey.get(record).get());
+    }
+
+    @Test public void
+    deserialise_string() {
+        String value = UUID.randomUUID().toString();
+        BsonDocument doc = new BsonDocument();
+        doc.put("my-value", new BsonString(value));
+        Key<String> stringKey = Key.named("my-value");
+
+        Record record = BsonRecordDeserialiser.builder()
+                .readString(stringKey)
+                .get()
+                .apply(doc);
+        assertEquals("wrong string value", value, stringKey.get(record).get());
+    }
+}

--- a/octarine-bson/src/test/java/com/codepoetics/octarine/bson/RecordToBson.java
+++ b/octarine-bson/src/test/java/com/codepoetics/octarine/bson/RecordToBson.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson;
+
+
+import com.codepoetics.octarine.bson.data.Address;
+import com.codepoetics.octarine.bson.data.Person;
+import com.codepoetics.octarine.bson.serialisation.BsonRecordSerialiser;
+import com.codepoetics.octarine.bson.serialisation.BsonSerialisers;
+import com.codepoetics.octarine.records.Record;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.junit.Test;
+
+import java.awt.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class RecordToBson {
+
+    public static final java.util.List<String> ADDRESS_LINES = Arrays.asList("13 Rue Morgue", "PO3 1TP");
+
+    @Test public void
+    convert_basic_record_to_bson() {
+        Record person = Record.of(
+                Person.name.of("Dominic"),
+                Person.age.of(39));
+
+        BsonRecordSerialiser serializer = BsonRecordSerialiser.builder()
+                .writeString(Person.name)
+                .writeInteger(Person.age)
+                .get();
+
+        BsonDocument doc = (BsonDocument) serializer.apply(person);
+        assertEquals("Invalid name", "Dominic", doc.getString("name").getValue());
+        assertEquals("invalid age", 39, doc.getInt32("age").getValue());
+    }
+
+    @Test public void
+    convert_record_to_bson_when_field_names_do_not_match_key_names() {
+        Record person = Record.of(
+                Person.name.of("Dominic"),
+                Person.age.of(39));
+
+        BsonRecordSerialiser serializer = BsonRecordSerialiser.builder()
+                .writeString(Person.name, "foo")
+                .writeInteger(Person.age, "bar")
+                .get();
+
+        BsonDocument doc = (BsonDocument) serializer.apply(person);
+        assertEquals("Invalid name", "Dominic", doc.getString("foo").getValue());
+        assertEquals("invalid age", 39, doc.getInt32("bar").getValue());
+    }
+
+    @Test public void
+    convert_record_with_sub_record_to_bson() {
+        Record person = Record.of(
+                Person.name.of("Dominic"),
+                Person.age.of(39),
+                Person.address.of(Address.addressLines.of(ADDRESS_LINES)));
+
+        BsonRecordSerialiser addressSerialiser = BsonRecordSerialiser.builder()
+                .writeList(Address.addressLines, BsonSerialisers.toString)
+                .get();
+
+        BsonRecordSerialiser serializer = BsonRecordSerialiser.builder()
+                .writeString(Person.name)
+                .writeInteger(Person.age)
+                .write(Person.address, addressSerialiser)
+                .get();
+
+        BsonDocument doc = (BsonDocument) serializer.apply(person);
+        assertEquals("Invalid name", "Dominic", doc.getString("name").getValue());
+        assertEquals("invalid age", 39, doc.getInt32("age").getValue());
+        BsonDocument bsonAddress = doc.getDocument("address");
+        assertNotNull("address was null", bsonAddress);
+        BsonArray bsonLines = bsonAddress.getArray("addressLines");
+        assertNotNull("addressLines was null", bsonLines);
+        List<String> bsonList = bsonLines.getValues().stream().map(v -> ((BsonString) v).getValue()).collect(Collectors.toList());
+        assertEquals("Address contents don't match", ADDRESS_LINES, bsonList);
+    }
+
+
+    @Test public void
+    convert_record_with_custom_type_to_bson() {
+        Record person = Record.of(
+                Person.name.of("Dominic"),
+                Person.age.of(39),
+                Person.favouriteColour.of(Color.RED));
+
+        BsonRecordSerialiser serializer = BsonRecordSerialiser.builder()
+                .writeString(Person.name)
+                .writeInteger(Person.age)
+                .write(Person.favouriteColour, Person.colourToBson)
+                .get();
+
+        BsonDocument doc = (BsonDocument) serializer.apply(person);
+        assertEquals("Invalid name", "Dominic", doc.getString("name").getValue());
+        assertEquals("invalid age", 39, doc.getInt32("age").getValue());
+        assertEquals("Invalid colour", Person.colourToString.apply(Color.RED), doc.getString("favouriteColour").getValue());
+    }
+}

--- a/octarine-bson/src/test/java/com/codepoetics/octarine/bson/SerialisationTest.java
+++ b/octarine-bson/src/test/java/com/codepoetics/octarine/bson/SerialisationTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson;
+
+
+import com.codepoetics.octarine.bson.serialisation.BsonMapSerialiser;
+import com.codepoetics.octarine.bson.serialisation.BsonRecordSerialiser;
+import com.codepoetics.octarine.bson.serialisation.BsonSerialisers;
+import com.codepoetics.octarine.records.Key;
+import com.codepoetics.octarine.records.Record;
+import org.bson.BsonDocument;
+import org.bson.types.ObjectId;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SerialisationTest {
+    Random random = new Random();
+
+    @Test public void
+    write_map_to_bson() {
+        Map<String, Integer> mapToSerialise = new HashMap<>();
+        mapToSerialise.put("foo", 42);
+        mapToSerialise.put("bar", 666);
+
+        BsonDocument doc = (BsonDocument) BsonMapSerialiser
+                .writingValuesWith(BsonSerialisers.toInteger)
+                .apply(mapToSerialise);
+
+        assertEquals("invalid foo", 42, doc.getInt32("foo").getValue());
+        assertEquals("invalid bar", 666, doc.getInt32("bar").getValue());
+    }
+
+    @Test public void
+    serialise_boolean() {
+        Key<Boolean> booleanKey = Key.named("my-value");
+
+        BsonRecordSerialiser serialiser = BsonRecordSerialiser.builder()
+                .writeBoolean(booleanKey)
+                .get();
+
+        Record trueRecord = Record.of(booleanKey.of(true));
+        BsonDocument trueDoc = (BsonDocument) serialiser.apply(trueRecord);
+        assertTrue("wasn't true", trueDoc.getBoolean("my-value").getValue());
+
+        Record falseRecord = Record.of(booleanKey.of(false));
+        BsonDocument falseDoc = (BsonDocument) serialiser.apply(falseRecord);
+        assertFalse("wasn't false", falseDoc.getBoolean("my-value").getValue());
+    }
+
+    @Test public void
+    serialise_date() {
+        Date value = new Date();
+        Key<Date> dateKey = Key.named("my-value");
+        Record record = Record.of(dateKey.of(value));
+
+        BsonDocument doc = (BsonDocument) BsonRecordSerialiser.builder()
+                .writeDate(dateKey)
+                .get()
+                .apply(record);
+        assertEquals("wrong date value", value.getTime(), doc.getDateTime("my-value").getValue());
+    }
+
+    @Test public void
+    serialise_double() {
+        double value = random.nextDouble();
+        Key<Double> doubleKey = Key.named("my-value");
+        Record record = Record.of(doubleKey.of(value));
+
+        BsonDocument doc = (BsonDocument) BsonRecordSerialiser.builder()
+                .writeDouble(doubleKey)
+                .get()
+                .apply(record);
+        assertEquals("wrong double value", value, doc.getDouble("my-value").getValue(), 0.0001);
+    }
+
+    @Test public void
+    serialise_integer() {
+        int value = random.nextInt();
+        Key<Integer> integerKey = Key.named("my-value");
+        Record record = Record.of(integerKey.of(value));
+
+        BsonDocument doc = (BsonDocument) BsonRecordSerialiser.builder()
+                .writeInteger(integerKey)
+                .get()
+                .apply(record);
+        assertEquals("wrong int value", value, doc.getInt32("my-value").getValue());
+    }
+
+    @Test public void
+    serialise_long() {
+        long value = random.nextLong();
+        Key<Long> longKey = Key.named("my-value");
+        Record record = Record.of(longKey.of(value));
+
+        BsonDocument doc = (BsonDocument) BsonRecordSerialiser.builder()
+                .writeLong(longKey)
+                .get()
+                .apply(record);
+        assertEquals("wrong long value", value, doc.getInt64("my-value").getValue());
+    }
+
+    @Test public void
+    serialise_object_id() {
+        ObjectId value = new ObjectId(new Date(), random.nextInt(0xffffff));
+        Key<ObjectId> idKey = Key.named("my-value");
+        Record record = Record.of(idKey.of(value));
+
+        BsonDocument doc = (BsonDocument) BsonRecordSerialiser.builder()
+                .writeObjectId(idKey)
+                .get()
+                .apply(record);
+        assertEquals("wrong ObjectId value", value, doc.getObjectId("my-value").getValue());
+    }
+
+    @Test public void
+    serialise_string() {
+        String value = UUID.randomUUID().toString();
+        Key<String> stringKey = Key.named("my-value");
+        Record record = Record.of(stringKey.of(value));
+
+        BsonDocument doc = (BsonDocument) BsonRecordSerialiser.builder()
+                .writeString(stringKey)
+                .get()
+                .apply(record);
+        assertEquals("wrong string value", value, doc.getString("my-value").getValue());
+    }
+}

--- a/octarine-bson/src/test/java/com/codepoetics/octarine/bson/data/Address.java
+++ b/octarine-bson/src/test/java/com/codepoetics/octarine/bson/data/Address.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson.data;
+
+import com.codepoetics.octarine.records.KeySet;
+import com.codepoetics.octarine.records.ListKey;
+import com.codepoetics.octarine.records.Schema;
+
+import static com.codepoetics.octarine.Octarine.$L;
+
+public interface Address {
+
+    KeySet mandatoryKeys = new KeySet();
+    ListKey<String> addressLines = mandatoryKeys.add($L("addressLines"));
+
+    Schema<Address> schema = (record, validationErrors) ->
+            mandatoryKeys.accept(record, validationErrors);
+}
+

--- a/octarine-bson/src/test/java/com/codepoetics/octarine/bson/data/Person.java
+++ b/octarine-bson/src/test/java/com/codepoetics/octarine/bson/data/Person.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.codepoetics.octarine.bson.data;
+
+import com.codepoetics.octarine.bson.deserialisation.BsonDeserialiser;
+import com.codepoetics.octarine.bson.deserialisation.BsonDeserialisers;
+import com.codepoetics.octarine.bson.serialisation.BsonSerialiser;
+import com.codepoetics.octarine.bson.serialisation.BsonSerialisers;
+import com.codepoetics.octarine.records.Key;
+import com.codepoetics.octarine.records.KeySet;
+import com.codepoetics.octarine.records.ValidRecordKey;
+
+import java.awt.Color;
+import java.util.function.Function;
+
+import static com.codepoetics.octarine.Octarine.$;
+import static com.codepoetics.octarine.Octarine.$V;
+
+public interface Person {
+
+    KeySet mandatoryKeys = new KeySet();
+    Key<String> name = mandatoryKeys.add($("name"));
+    Key<Integer> age = mandatoryKeys.add($("age"));
+    Key<Color> favouriteColour = mandatoryKeys.add($("favouriteColour"));
+
+    ValidRecordKey<Address> address =
+            mandatoryKeys.add($V("address", Address.schema));
+
+    Function<Color, String> colourToString = c -> "0x" + Integer.toHexString(c.getRGB()).toUpperCase().substring(2);
+
+    BsonSerialiser<Color> colourToBson = c -> BsonSerialisers.toString.apply(colourToString.apply(c));
+
+    BsonDeserialiser<Color> colourFromBson = b -> Color.decode(BsonDeserialisers.ofString.apply(b));
+}

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <module>octarine-json</module>
         <module>octarine-joins</module>
         <module>octarine-recordjoins</module>
+        <module>octarine-bson</module>
     </modules>
 
     <dependencies>


### PR DESCRIPTION
We serialise to/from BsonDocument rather than producing BSON compatible byte streams so that the results of the serialisation can be used with the mongo driver API.