### PR TITLE
Constant lens

### DIFF
--- a/octarine-functional/src/main/java/com/codepoetics/octarine/functional/lenses/Lens.java
+++ b/octarine-functional/src/main/java/com/codepoetics/octarine/functional/lenses/Lens.java
@@ -86,4 +86,14 @@ public interface Lens<T, V> {
         );
     }
 
+    /**
+     * Used to construct a lens that always returns the given value.
+     * When set method is used the supplied value is returned unchanged.
+     */
+    static <T, V2> Lens<T, V2> constant(V2 value) {
+        return Lens.of(
+                t -> value,
+                (t, v) -> t
+        );
+    }
 }

--- a/octarine-functional/src/test/java/com/codepoetics/octarine/functional/lenses/LensesTest.java
+++ b/octarine-functional/src/test/java/com/codepoetics/octarine/functional/lenses/LensesTest.java
@@ -94,4 +94,17 @@ public class LensesTest {
 
         assertThat(secondItemPluraliser.apply(strings), equalTo(new String[]{"cow", "ducks"}));
     }
+
+    @Test public void
+    constant_lens_always_returns_same_value() {
+        final Lens<PMap<String, String>, String> bIsFor = Lens.constant("bicycle");
+        assertThat(bIsFor.get(pmap), equalTo("bicycle"));
+
+    }
+
+    @Test public void
+    constant_lens_set_does_not_modify_supplied_value() {
+        final Lens<PMap<String, String>, String> bIsFor = Lens.constant("bicycle");
+        assertThat(bIsFor.set(pmap, "artichoke").get("a"), equalTo("apple"));
+    }
 }


### PR DESCRIPTION
In some cases we might want to supply a lens to another function but want it to return a predefined constant value rather than the value from the supplied object. Likewise the constant lens's setter does not modify the supplied value.