### PR TITLE
Prevent infinite loops in octarine deserialisation

### DIFF
--- a/octarine-json/src/main/java/com/codepoetics/octarine/json/deserialisation/RecordDeserialiser.java
+++ b/octarine-json/src/main/java/com/codepoetics/octarine/json/deserialisation/RecordDeserialiser.java
@@ -140,7 +140,11 @@ public final class RecordDeserialiser implements SafeDeserialiser<Record> {
             return Record.empty();
         }
 
-        while (parser.nextValue() != JsonToken.END_OBJECT) {
+        /*
+         * When the parser has hit the end of input nextToken() will always return null.
+         * So need to prevent infinite loops we check the parser closed flag.
+         */
+        while (!parser.isClosed() && (parser.nextValue() != JsonToken.END_OBJECT)) {
             String fieldName = parser.getCurrentName();
             Optional<Value> result = parserMapper.apply(fieldName, parser);
             if (result.isPresent()) {


### PR DESCRIPTION
The jackson JsonParser nextToken() method will always return null once the end of the input has been reached. We therefore need to check the parser state in order to prevent infinite loops.

We also add an additional check to ListDeserialiser when called from the top level which makes it more robust when parsing JSON with a list instead of an object as the root element.