### PR TITLE
Allow BsonMapSerialiser to handle maps with null values

### DIFF
--- a/octarine-bson/src/main/java/com/codepoetics/octarine/bson/serialisation/BsonMapSerialiser.java
+++ b/octarine-bson/src/main/java/com/codepoetics/octarine/bson/serialisation/BsonMapSerialiser.java
@@ -26,7 +26,9 @@ public class BsonMapSerialiser<T> implements SafeBsonSerialiser<Map<String, ? ex
     public BsonValue applyUnsafe(Map<String, ? extends T> values) throws IOException {
         final BsonDocument doc = new BsonDocument();
         for (Map.Entry<String, ? extends T> e : values.entrySet()) {
-            doc.put(e.getKey(), valueSerialiser.apply(e.getValue()));
+            if (null != e.getValue()) {
+                doc.put(e.getKey(), valueSerialiser.apply(e.getValue()));
+            }
         }
         return doc;
     }

--- a/octarine-bson/src/test/java/com/codepoetics/octarine/bson/SerialisationTest.java
+++ b/octarine-bson/src/test/java/com/codepoetics/octarine/bson/SerialisationTest.java
@@ -11,6 +11,7 @@ import com.codepoetics.octarine.bson.serialisation.BsonSerialisers;
 import com.codepoetics.octarine.records.Key;
 import com.codepoetics.octarine.records.Record;
 import org.bson.BsonDocument;
+import org.bson.BsonInvalidOperationException;
 import org.bson.types.ObjectId;
 import org.junit.Test;
 
@@ -23,6 +24,7 @@ import java.util.UUID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class SerialisationTest {
     Random random = new Random();
@@ -39,6 +41,25 @@ public class SerialisationTest {
 
         assertEquals("invalid foo", 42, doc.getInt32("foo").getValue());
         assertEquals("invalid bar", 666, doc.getInt32("bar").getValue());
+    }
+
+    @Test public void
+    write_map_with_null_values_to_bson() {
+        Map<String, Integer> mapToSerialise = new HashMap<>();
+        mapToSerialise.put("foo", 42);
+        mapToSerialise.put("bar", null);
+
+        BsonDocument doc = (BsonDocument) BsonMapSerialiser
+                .writingValuesWith(BsonSerialisers.toInteger)
+                .apply(mapToSerialise);
+
+        assertEquals("invalid foo", 42, doc.getInt32("foo").getValue());
+        try {
+            Integer value = doc.getInt32("bar").getValue();
+            fail("bar should not have been written to the document");
+        } catch (BsonInvalidOperationException e) {
+            // expected
+        }
     }
 
     @Test public void


### PR DESCRIPTION
Add a null check to BsonMapSerialiser and a test to verify the behaviour