### PR TITLE
Remove octarine-bson depepency on mongo-java-driver uber-jar

### DIFF
--- a/octarine-bson/pom.xml
+++ b/octarine-bson/pom.xml
@@ -18,8 +18,8 @@
 
         <dependency>
             <groupId>org.mongodb</groupId>
-            <artifactId>mongo-java-driver</artifactId>
-            <version>3.0.4</version>
+            <artifactId>bson</artifactId>
+            <version>4.2.3</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The mongo-java-driver and mongodb-driver “uber-jars” are no longer published. Applications that reference either of these artifacts must switch to either mongodb-driver-sync or mongodb-driver-legacy, depending on which API is being used. Care should be taken to ensure that neither of the uber-jars are included via a transitive dependency, as that could introduce versioning conflicts.

Right now because of above, any application using octarine-bson cannot move to mongo 4.x driver because octarine-bson is pulling in the old mongo-java-driver 3.x uber-jar and causing a versioning conflict.
In reality, octarine-bson only needs org.mongodb.bson so change it to only depend on that, and avoid the versioning conflict.